### PR TITLE
Do not immediately fail if required rubygems are not installed

### DIFF
--- a/lib/puppet/provider/librenms_device/api.rb
+++ b/lib/puppet/provider/librenms_device/api.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
-require 'rubygems'
-require 'rest_client'
-require 'json'
-
 Puppet::Type.type(:librenms_device).provide(:api) do
+
+  require 'rubygems'
+  require 'rest_client'
+  require 'json'
+
   defaultfor kernel: 'Linux'
 
   def exists?

--- a/lib/puppet/type/librenms_device.rb
+++ b/lib/puppet/type/librenms_device.rb
@@ -1,10 +1,12 @@
-require 'uri'
+
 
 # frozen_string_literal: true
 
 # LibreNMS device type for Puppet
 module Puppet
   Type.newtype(:librenms_device) do
+    require 'uri'
+
     @doc = 'Manage LibreNMS devices'
 
     validate do


### PR DESCRIPTION
This allows Puppet to install the missing gems

Signed-off-by: Samuli Seppänen <samuli@openvpn.net>